### PR TITLE
Add Jetson Orin compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ git checkout windows
 ```
 This disables multiprocessing which causes an issue with shared memory as discussed [here](https://github.com/rmurai0610/MASt3R-SLAM/issues/21).
 
+## Jetson Orin
+When running on NVIDIA Jetson Orin devices, the CUDA extension needs to compile
+for compute capability 8.7.  The provided `setup.py` includes the `sm_87`
+architecture flag so it can be built with the JetPack CUDA toolkit.
+
 ## Examples
 ```
 bash ./scripts/download_tum.sh

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ if has_cuda:
         "-gencode=arch=compute_75,code=sm_75",
         "-gencode=arch=compute_80,code=sm_80",
         "-gencode=arch=compute_86,code=sm_86",
+        "-gencode=arch=compute_87,code=sm_87",
     ]
     ext_modules = [
         CUDAExtension(


### PR DESCRIPTION
## Summary
- add sm_87 compile flag in setup.py for Jetson Orin
- document Jetson Orin support in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asmk')*
- `python -m py_compile setup.py`

------
https://chatgpt.com/codex/tasks/task_e_684f1ee49d7c83288c702830fbae5143