### PR TITLE
Add Raspberry Pi 5 CPU compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ When running on NVIDIA Jetson Orin devices, the CUDA extension needs to compile
 for compute capability 8.7.  The provided `setup.py` includes the `sm_87`
 architecture flag so it can be built with the JetPack CUDA toolkit.
 
+## Raspberry Pi 5
+The Raspberry&nbsp;Pi&nbsp;5 does not provide CUDA support. When installing on this
+platform the build will skip the CUDA extension and use slower CPU
+implementations for `iter_proj` and `refine_matches`. Functions related to pose
+optimisation (`gauss_newton_rays` and `gauss_newton_calib`) are currently not
+implemented for CPU and will raise a `NotImplementedError` if called.
+Install PyTorch for ARM64 and run `pip install --no-build-isolation -e .` to
+install the package.
+
 ## Examples
 ```
 bash ./scripts/download_tum.sh

--- a/mast3r_slam/backends/__init__.py
+++ b/mast3r_slam/backends/__init__.py
@@ -1,0 +1,16 @@
+try:
+    import mast3r_slam_backends as _impl
+except ImportError:  # pragma: no cover - fallback for CPU-only devices
+    from . import cpu as _impl
+
+gauss_newton_rays = _impl.gauss_newton_rays
+gauss_newton_calib = _impl.gauss_newton_calib
+iter_proj = _impl.iter_proj
+refine_matches = _impl.refine_matches
+
+__all__ = [
+    "gauss_newton_rays",
+    "gauss_newton_calib",
+    "iter_proj",
+    "refine_matches",
+]

--- a/mast3r_slam/backends/cpu.py
+++ b/mast3r_slam/backends/cpu.py
@@ -1,0 +1,106 @@
+import torch
+
+def _bilinear_sample(img, u, v):
+    h, w = img.shape[0], img.shape[1]
+    u = float(u); v = float(v)
+    u11 = int(torch.floor(torch.tensor(u)))
+    v11 = int(torch.floor(torch.tensor(v)))
+    du = u - u11
+    dv = v - v11
+    w11 = du * dv
+    w12 = (1.0 - du) * dv
+    w21 = du * (1.0 - dv)
+    w22 = (1.0 - du) * (1.0 - dv)
+    r11 = img[v11 + 1, u11 + 1]
+    r12 = img[v11 + 1, u11]
+    r21 = img[v11, u11 + 1]
+    r22 = img[v11, u11]
+    return (
+        w11 * r11 +
+        w12 * r12 +
+        w21 * r21 +
+        w22 * r22
+    )
+
+def iter_proj(rays_img_with_grad, pts_3d_norm, p_init, max_iter, lambda_init, cost_thresh):
+    b, h, w, _ = rays_img_with_grad.shape
+    n = pts_3d_norm.shape[1]
+    device = rays_img_with_grad.device
+    p_new = torch.zeros_like(p_init)
+    converged = torch.zeros(b, n, dtype=torch.bool, device=device)
+    for bi in range(b):
+        for ni in range(n):
+            u = float(p_init[bi, ni, 0])
+            v = float(p_init[bi, ni, 1])
+            u = max(1.0, min(w - 2.0, u))
+            v = max(1.0, min(h - 2.0, v))
+            lam = lambda_init
+            for _ in range(max_iter):
+                sample = _bilinear_sample
+                vec = sample(rays_img_with_grad[bi], u, v)
+                r = vec[:3]
+                gx = vec[3:6]
+                gy = vec[6:9]
+                r = r / torch.linalg.norm(r)
+                err = r - pts_3d_norm[bi, ni]
+                cost = torch.dot(err, err)
+                A00 = torch.dot(gx, gx) + lam
+                A01 = torch.dot(gx, gy)
+                A11 = torch.dot(gy, gy) + lam
+                b0 = -torch.dot(err, gx)
+                b1 = -torch.dot(err, gy)
+                det = A00 * A11 - A01 * A01
+                delta_u = (A11 * b0 - A01 * b1) / det
+                delta_v = (-A01 * b0 + A00 * b1) / det
+                u_new = max(1.0, min(w - 2.0, u + delta_u))
+                v_new = max(1.0, min(h - 2.0, v + delta_v))
+                vec2 = sample(rays_img_with_grad[bi], u_new, v_new)
+                r2 = vec2[:3]
+                r2 = r2 / torch.linalg.norm(r2)
+                err2 = r2 - pts_3d_norm[bi, ni]
+                new_cost = torch.dot(err2, err2)
+                if new_cost < cost:
+                    u, v = u_new, v_new
+                    lam *= 0.1
+                    if new_cost < cost_thresh:
+                        converged[bi, ni] = True
+                else:
+                    lam *= 10.0
+                    if cost < cost_thresh:
+                        converged[bi, ni] = True
+            p_new[bi, ni, 0] = u
+            p_new[bi, ni, 1] = v
+    return p_new, converged
+
+def refine_matches(D11, D21, p1, radius, dilation_max):
+    b, n = p1.shape[:2]
+    h, w = D11.shape[1:3]
+    p1_new = p1.clone()
+    for bi in range(b):
+        for ni in range(n):
+            u0 = int(p1[bi, ni, 0])
+            v0 = int(p1[bi, ni, 1])
+            u_new, v_new = u0, v0
+            for d in range(dilation_max, 0, -1):
+                rd = radius * d
+                diam = 2 * rd + 1
+                max_score = float('-inf')
+                for i in range(0, diam, d):
+                    for j in range(0, diam, d):
+                        u = u0 - rd + i
+                        v = v0 - rd + j
+                        if 0 <= u < w and 0 <= v < h:
+                            score = torch.dot(D21[bi, ni], D11[bi, v, u])
+                            if score > max_score:
+                                max_score = score
+                                u_new, v_new = u, v
+                u0, v0 = u_new, v_new
+            p1_new[bi, ni, 0] = u_new
+            p1_new[bi, ni, 1] = v_new
+    return (p1_new,)
+
+def gauss_newton_rays(*args, **kwargs):
+    raise NotImplementedError("gauss_newton_rays not available without CUDA")
+
+def gauss_newton_calib(*args, **kwargs):
+    raise NotImplementedError("gauss_newton_calib not available without CUDA")

--- a/mast3r_slam/global_opt.py
+++ b/mast3r_slam/global_opt.py
@@ -6,7 +6,7 @@ from mast3r_slam.geometry import (
     constrain_points_to_ray,
 )
 from mast3r_slam.mast3r_utils import mast3r_match_symmetric
-import mast3r_slam_backends
+from mast3r_slam.backends import gauss_newton_rays, gauss_newton_calib
 
 
 class FactorGraph:
@@ -137,7 +137,7 @@ class FactorGraph:
         delta_thresh = self.cfg["delta_norm"]
 
         pose_data = T_WCs.data[:, 0, :]
-        mast3r_slam_backends.gauss_newton_rays(
+        gauss_newton_rays(
             pose_data,
             Xs,
             Cs,
@@ -187,7 +187,7 @@ class FactorGraph:
         img_size = self.frames[0].img.shape[-2:]
         height, width = img_size
 
-        mast3r_slam_backends.gauss_newton_calib(
+        gauss_newton_calib(
             pose_data,
             Xs,
             Cs,

--- a/mast3r_slam/matching.py
+++ b/mast3r_slam/matching.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn.functional as F
 import mast3r_slam.image as img_utils
 from mast3r_slam.config import config
-import mast3r_slam_backends
+from mast3r_slam.backends import iter_proj, refine_matches
 
 
 def match(X11, X21, D11, D21, idx_1_to_2_init=None):
@@ -57,7 +57,7 @@ def match_iterative_proj(X11, X21, D11, D21, idx_1_to_2_init=None):
     rays_with_grad_img, pts3d_norm, p_init = prep_for_iter_proj(
         X11, X21, idx_1_to_2_init
     )
-    p1, valid_proj2 = mast3r_slam_backends.iter_proj(
+    p1, valid_proj2 = iter_proj(
         rays_with_grad_img,
         pts3d_norm,
         p_init,
@@ -76,7 +76,7 @@ def match_iterative_proj(X11, X21, D11, D21, idx_1_to_2_init=None):
     valid_proj2 = valid_proj2 & valid_dists2
 
     if cfg["radius"] > 0:
-        (p1,) = mast3r_slam_backends.refine_matches(
+        (p1,) = refine_matches(
             D11.half(),
             D21.view(b, h * w, -1).half(),
             p1,

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ if has_cuda:
         )
     ]
 else:
-    print("CUDA not found, cannot compile backend!")
+    print("CUDA not found, building without backend extension")
+    ext_modules = []
 
 setup(
     ext_modules=ext_modules,


### PR DESCRIPTION
## Summary
- add CPU fallbacks for iter_proj and refine_matches
- load CPU implementations when CUDA extension is missing
- handle missing CUDA in setup.py
- document Raspberry Pi 5 limitations

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asmk')*

------
https://chatgpt.com/codex/tasks/task_e_684f20aee2648328b1a4740a933ac1c2